### PR TITLE
home02: fix the grammatical error in the "workflow" section

### DIFF
--- a/src/components/home/Childoneworkflow.jsx
+++ b/src/components/home/Childoneworkflow.jsx
@@ -94,8 +94,8 @@ function ChildOneWorkflow() {
                 network forks, AMAs.
                 <br />
                 <br />
-                Search event by geography: USA, London, etc. and subscribe
-                online to events and add them to your calendar or create alerts.
+                Search event by geography: USA, London, Online, etc. and subscribe
+                to events and add them to your calendar and create alerts.
               </CardText>
             </div>
             <div className="absolute bottom-10">


### PR DESCRIPTION
corrected the grammatical error in the description of the "Track important events" flip card, in the workflow section

![image](https://user-images.githubusercontent.com/76987753/169016292-614115ab-e4cc-41e9-a54e-f30ce8d6eaad.png)

