### PR TITLE
home18: prevent partner links from loading in parent tab

### DIFF
--- a/src/components/home/Partners.jsx
+++ b/src/components/home/Partners.jsx
@@ -16,7 +16,7 @@ function Partners() {
             {partners.map((item) => {
               return (
                 <figure key={item.id} className="flex justify-center">
-                  <a href={item.link}>
+                  <a target="_blank" href={item.link}>
                     <img
                       src={item.img}
                       className={`my-4 ${item.size}`}
@@ -36,7 +36,7 @@ function Partners() {
                   className="flex flex-col justify-center items-center"
                 >
                   <figure className=" rounded-full mb-2">
-                    <a href={item.link}>
+                    <a target="_blank" href={item.link}>
                       <img
                         src={item.img}
                         className="w-[80px] h-[80px]"
@@ -47,7 +47,11 @@ function Partners() {
                   <p className="mb-2 text-sm text-platinum">
                     {item.contributor}
                   </p>
-                  <a href={item.link} className="text-xs text-aluminium justify-self-center bg-black rounded-full px-4 py-2">
+                  <a
+                    target="_blank"
+                    href={item.link}
+                    className="text-xs text-aluminium justify-self-center bg-black rounded-full px-4 py-2"
+                  >
                     {item.handle}
                   </a>
                 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/76987753/169029422-a2d718fc-1c7e-4941-8f47-64ebe01a0929.png)

outgoing links from this section loaded in the parent tab; this PR fixes that by loading them in another tab.