### PR TITLE
[fix] Move OG tags to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
         data-react-helmet="true"
       />
       {/* Opengraph meta tags for Facebook & LinkedIn */}
-      <meta property="og:url" content={domain} data-react-helmet="true" />
-      <meta property="og:type" content={"website"} data-react-helmet="true" />
+      <meta property="og:url" content="https://alphaday.com" data-react-helmet="true" />
+      <meta property="og:type" content="website" data-react-helmet="true" />
       <meta
         property="og:title"
         content="Alphaday"


### PR DESCRIPTION
This PR should move put the tags @ index.html. Social media crawlers only read the page's source without Javascript. So React Helmet does not work.