### PR TITLE
chore: update sitemap script

### DIFF
--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -9,31 +9,6 @@ const links = [
         priority: "1.00",
         changefreq: "weekly",
     },
-    {
-        loc: `${baseUrl}/blog`,
-        priority: "0.80",
-        changefreq: "weekly",
-    },
-    {
-        loc: `${baseUrl}/b/alpha`,
-        priority: "0.80",
-        changefreq: "weekly",
-    },
-    {
-        loc: `${baseUrl}/b/beginner`,
-        priority: "0.80",
-        changefreq: "weekly",
-    },
-    {
-        loc: `${baseUrl}/b/nft`,
-        priority: "0.80",
-        changefreq: "weekly",
-    },
-    {
-        loc: `${baseUrl}/b/trading`,
-        priority: "0.80",
-        changefreq: "weekly",
-    },
 ];
 
 sitemaps(filePath, links);

--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -21,6 +21,11 @@ const links = [
         changefreq: "weekly",
     },
     {
+        loc: `${appUrl}/calendar`,
+        priority: "0.80",
+        changefreq: "weekly",
+    },
+    {
         loc: `${appUrl}/b/alpha`,
         priority: "0.80",
         changefreq: "weekly",

--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -2,11 +2,47 @@ const sitemaps = require("sitemaps");
 
 const filePath = `${__dirname}/../dist/sitemap.xml`;
 const baseUrl = "https://www.alphaday.com";
+const appUrl = "https://app.alphaday.com";
 
 const links = [
     {
         loc: baseUrl,
         priority: "1.00",
+        changefreq: "monthly",
+    },
+    {
+        loc: `${baseUrl}/blog`,
+        priority: "0.80",
+        changefreq: "weekly",
+    },
+    {
+        loc: appUrl,
+        priority: "1.00",
+        changefreq: "weekly",
+    },
+    {
+        loc: `${appUrl}/b/alpha`,
+        priority: "0.80",
+        changefreq: "weekly",
+    },
+    {
+        loc: `${appUrl}/b/beginner`,
+        priority: "0.80",
+        changefreq: "weekly",
+    },
+    {
+        loc: `${appUrl}/b/nft`,
+        priority: "0.80",
+        changefreq: "weekly",
+    },
+    {
+        loc: `${appUrl}/b/trading`,
+        priority: "0.80",
+        changefreq: "weekly",
+    },
+    {
+        loc: `${appUrl}/b/arbitrum`,
+        priority: "0.80",
         changefreq: "weekly",
     },
 ];

--- a/scripts/build-sitemap.js
+++ b/scripts/build-sitemap.js
@@ -1,7 +1,19 @@
 const sitemaps = require("sitemaps");
+const { resolve } = require("path");
+const { existsSync, mkdirSync } = require("fs");
 
-const filePath = `${__dirname}/../dist/sitemap.xml`;
-const baseUrl = "https://www.alphaday.com";
+// path to app build directory
+const distPath = resolve(__dirname, "../dist");
+const outputName = "sitemap.xml";
+const outputPath = `${distPath}/${outputName}`;
+
+// ensure the build directory exists
+// so we can run this script independent of the build.
+if (!existsSync(distPath)) {
+    mkdirSync(distPath);
+}
+
+const baseUrl = "https://alphaday.com";
 const appUrl = "https://app.alphaday.com";
 
 const links = [
@@ -22,34 +34,34 @@ const links = [
     },
     {
         loc: `${appUrl}/calendar`,
-        priority: "0.80",
+        priority: "0.60",
         changefreq: "weekly",
     },
     {
         loc: `${appUrl}/b/alpha`,
-        priority: "0.80",
+        priority: "0.70",
         changefreq: "weekly",
     },
     {
         loc: `${appUrl}/b/beginner`,
-        priority: "0.80",
+        priority: "0.60",
         changefreq: "weekly",
     },
     {
         loc: `${appUrl}/b/nft`,
-        priority: "0.80",
+        priority: "0.60",
         changefreq: "weekly",
     },
     {
         loc: `${appUrl}/b/trading`,
-        priority: "0.80",
+        priority: "0.60",
         changefreq: "weekly",
     },
     {
         loc: `${appUrl}/b/arbitrum`,
-        priority: "0.80",
+        priority: "0.60",
         changefreq: "weekly",
     },
 ];
 
-sitemaps(filePath, links);
+sitemaps(outputPath, links);


### PR DESCRIPTION
A few Key details about this PR.

- A short RnD was carried out to discover just how bots handle sitemaps with multiple domain
- The research showed that [Google recently allowed having multiple URLs of the same ownership data within a sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps?hl=en&visit_id=638088600569940269-1391256507&rd=1#manage-sitemaps-for-multiple-sites).
- Not only this, but [redirects or error pages are not to be in a sitemap](https://developers.google.com/search/blog/2008/01/sitemaps-faqs).
- Lastly, Google does allow us to add URLs we want robots to see. However, we would have to handle how to prevent normal users from visiting. This would need to be implemented by us.