### PR TITLE
[fix] ALPHA-1364 Add linkedin link to top of page as well 

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -56,10 +56,10 @@ function Navbar() {
           <div
             className={`fixed w-[91%] z-10 mx-auto lg:max-w-7xl flex justify-end`}
           >
-            <div className="relative items-center w-[100px] md:w-[140px] flex justify-end ease-in-out">
+            <div className="relative items-center w-[140px] flex justify-end ease-in-out">
               <div
                 ref={element2}
-                className="scroll-show flex justify-between items-center w-[150px]"
+                className="scroll-show flex justify-between items-center w-[160px]"
               >
                 <a
                   href={discord}

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -59,12 +59,13 @@ function Navbar() {
             <div className="relative items-center w-[100px] md:w-[140px] flex justify-end ease-in-out">
               <div
                 ref={element2}
-                className="scroll-show flex justify-between items-center w-[90px]"
+                className="scroll-show flex justify-between items-center w-[150px]"
               >
                 <a
                   href={discord}
                   target="_blank"
                   className="w-[40px] h-[40px] rounded-full bg-black flex justify-center items-center"
+                  title="Join us on Discord"
                 >
                   <img src={discordLogo} alt="discord" />
                 </a>
@@ -73,13 +74,16 @@ function Navbar() {
                   href={twitter}
                   target="_blank"
                   className="w-[40px] h-[40px] rounded-full bg-black flex justify-center items-center"
+                  title="Follow us on Twitter"
                 >
                   <img src={twitterLogo} alt="twitter" />
                 </a>
                 <a
                   target="_blank"
                   href={linkedin}
-                  className="w-[40px] h-[40px] rounded-full bg-black flex justify-center items-center">
+                  className="w-[40px] h-[40px] rounded-full bg-black flex justify-center items-center"
+                  title="Connect with us on LinkedIn"
+                >
                     <img src={linkedinLogo} alt="linkedin" />
                 </a>
               </div>

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -4,10 +4,11 @@ import alphaday from "../../images/logo.png";
 import LaunchAppButton from "../home/LaunchAppButton";
 import discordLogo from "../../images/socials/discord.svg";
 import twitterLogo from "../../images/socials/twitter.svg";
+import linkedinLogo from "../../images/socials/linkedin.svg";
 import config from "../../config";
 
 function Navbar() {
-  const { twitter, discord } = config;
+  const { twitter, discord, linkedin } = config;
   const showPosition = 492;
   const element = useRef(null);
   const element2 = useRef(null);
@@ -69,11 +70,17 @@ function Navbar() {
                 </a>
 
                 <a
-                  href="https://twitter.com/AlphadayHQ"
+                  href={twitter}
                   target="_blank"
                   className="w-[40px] h-[40px] rounded-full bg-black flex justify-center items-center"
                 >
                   <img src={twitterLogo} alt="twitter" />
+                </a>
+                <a
+                  target="_blank"
+                  href={linkedin}
+                  className="w-[40px] h-[40px] rounded-full bg-black flex justify-center items-center">
+                    <img src={linkedinLogo} alt="linkedin" />
                 </a>
               </div>
               <div ref={element} className="scroll-hide absolute mb-1">


### PR DESCRIPTION
This PR adds the linkedin link to the top. It also introduces "tooltips" for the social links as well.

<img width="375" alt="Screenshot 2023-02-17 at 09 12 43" src="https://user-images.githubusercontent.com/30146982/219589166-38c8e98d-ad0f-40ea-b4cf-a2841e0ff274.png">
