### PR TITLE
[fix] [ALPHA-1733] Ovelapping flipcard text

### DIFF
--- a/src/components/home/Track.jsx
+++ b/src/components/home/Track.jsx
@@ -70,7 +70,7 @@ function Track() {
               </ul>
               </CardText>
 
-              <div className="absolute bottom-0">
+              <div className="absolute md:bottom-0 -bottom-6">
                 <FlipCardClose handler={handleTrackToggler}>
                   <p className="mr-2">CLOSE</p>
                   <i className="ri-close-fill"></i>

--- a/src/components/home/Track.jsx
+++ b/src/components/home/Track.jsx
@@ -20,7 +20,7 @@ function Track() {
 
   return (
     <div className="grid grid-cols-1">
-      <FlipCard className="overflow-hidden h-[350px] sm:h-[450px] lg:h-[590px]">
+      <FlipCard className="overflow-hidden h-[360px] sm:h-[450px] lg:h-[590px]">
         <FlipCardInner className={`${trackCardToggler ? "flipThis" : ""}`}>
           <FlipCardFront>
             <div>


### PR DESCRIPTION
## Before
<img width="332" alt="Screenshot 2023-03-09 at 10 54 45" src="https://user-images.githubusercontent.com/39612820/223986093-d41341d5-52a8-4cee-b4ab-c48252a2c713.png">


## After

<img width="331" alt="Screenshot 2023-03-09 at 10 54 19" src="https://user-images.githubusercontent.com/39612820/223986129-1f7c8473-562f-4314-9622-556cbce413c9.png">
